### PR TITLE
With worker design

### DIFF
--- a/lib/conntrack-tp.c
+++ b/lib/conntrack-tp.c
@@ -33,8 +33,8 @@ static const char *ct_timeout_str[] = {
 
 /* Default timeout policy in seconds. */
 static unsigned int ct_dpif_netdev_tp_def[] = {
-    [CT_DPIF_TP_ATTR_TCP_SYN_SENT] = 5,
-    [CT_DPIF_TP_ATTR_TCP_SYN_RECV] = 5,
+    [CT_DPIF_TP_ATTR_TCP_SYN_SENT] = 2,
+    [CT_DPIF_TP_ATTR_TCP_SYN_RECV] = 2,
     [CT_DPIF_TP_ATTR_TCP_ESTABLISHED] = 10,
     [CT_DPIF_TP_ATTR_TCP_FIN_WAIT] = 1,
     [CT_DPIF_TP_ATTR_TCP_TIME_WAIT] = 1,


### PR DESCRIPTION
With revalidator as 100 seconds,
    CPS: 48M+
    Offloads: 10M+

With revalidator 10 seconds:
    CPS: 40M+
    offloads: 25M+

Configuration:

    export PATH=$PATH:/nic/tools/openvswitch/scripts/
    export DB_SOCK=/var/run/openvswitch/db.sock
    export DB_FILE=/var/run/openvswitch/conf.db

    mkdir -p /var/run/openvswitch/
    mkdir /var/log/openvswitch

    ovsdb-tool create $DB_FILE /nic/tools/openvswitch/vswitch.ovsschema

    echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
    cat /proc/meminfo | grep -i huge

    ovsdb-server --remote=punix:$DB_SOCK --remote=db:Open_vSwitch,Open_vSwitch,manager_options --detach --pidfile --log-file --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwi

    ovs-vsctl --no-wait set Open_vSwitch .
    other_config:dpdk-socket-mem="1024"
    ovs-vsctl --no-wait set Open_vSwitch .
    other_config:dpdk-lcore-mask=0xff00
    ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-mem-channels=4
    ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
    ovs-vsctl --no-wait set Open_vSwitch . other_config:per-port-memory=false
    ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true
    ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-main-lcore=0
    ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x00ff

    ovs-vsctl set Open_vSwitch . other_config:n-offload-threads=1
    ovs-vsctl set Open_vSwitch . other-config:n-revalidator-threads=1

    ovs-vsctl set Open_vSwitch . other_config:max-revalidator=10000
    ovs-vsctl set Open_vSwitch . other_config:max-idle=10000

    /data/ovs-vswitchd --pidfile --detach --log-file

    ovs-vsctl --no-wait add-br br0 -- set bridge br0 datapath_type=netdev
    ovs-appctl dpctl/ct-set-maxconns 80000000
    ovs-vsctl --no-wait add-port br0 dpdk0 -- set Interface dpdk0 type=dpdk options:dpdk-devargs="vdev=net_ionic0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 opti
    ovs-vsctl --no-wait add-port br0 dpdk1 -- set Interface dpdk1 type=dpdk options:dpdk-devargs="vdev=net_ionic1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 opti

    ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
    ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
    ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
    ovs-ofctl add-flow br0 "table=0, priority=40, actions=drop"
    ovs-appctl vlog/set off

    ovs-appctl dpctl/offload-stats-show
    start -f astf/simple_tr.py -m 50000 -d 1000 -t pairs=10.1.1.10|20.1.1.10,clients=50