### PR TITLE
Working 8L code with conntrack enabled

### DIFF
--- a/lib/conntrack-private.h
+++ b/lib/conntrack-private.h
@@ -143,6 +143,7 @@ struct conn {
     atomic_llong expiration;
     uint32_t mark;
     int seq_skew;
+    bool logged;
 
     /* Immutable data. */
     int32_t admit_zone; /* The zone for managing zone limit counts. */

--- a/lib/conntrack-tp.c
+++ b/lib/conntrack-tp.c
@@ -33,12 +33,12 @@ static const char *ct_timeout_str[] = {
 
 /* Default timeout policy in seconds. */
 static unsigned int ct_dpif_netdev_tp_def[] = {
-    [CT_DPIF_TP_ATTR_TCP_SYN_SENT] = 2,
-    [CT_DPIF_TP_ATTR_TCP_SYN_RECV] = 2,
-    [CT_DPIF_TP_ATTR_TCP_ESTABLISHED] = 10,
-    [CT_DPIF_TP_ATTR_TCP_FIN_WAIT] = 1,
-    [CT_DPIF_TP_ATTR_TCP_TIME_WAIT] = 1,
-    [CT_DPIF_TP_ATTR_TCP_CLOSE] = 1,
+    [CT_DPIF_TP_ATTR_TCP_SYN_SENT] = 10,
+    [CT_DPIF_TP_ATTR_TCP_SYN_RECV] = 10,
+    [CT_DPIF_TP_ATTR_TCP_ESTABLISHED] = 30,
+    [CT_DPIF_TP_ATTR_TCP_FIN_WAIT] = 10,
+    [CT_DPIF_TP_ATTR_TCP_TIME_WAIT] = 10,
+    [CT_DPIF_TP_ATTR_TCP_CLOSE] = 10,
     [CT_DPIF_TP_ATTR_UDP_FIRST] = 60,
     [CT_DPIF_TP_ATTR_UDP_SINGLE] = 60,
     [CT_DPIF_TP_ATTR_UDP_MULTIPLE] = 30,

--- a/lib/dpif-netdev.h
+++ b/lib/dpif-netdev.h
@@ -37,6 +37,10 @@ bool dpif_is_netdev(const struct dpif *);
 
 #define NR_QUEUE   1
 #define NR_PMD_THREADS 1
+rte_atomic64_t conn_est_count;
+rte_atomic64_t conn_del_count;
+rte_atomic64_t total_offloaded;
+bool start;
 
 #ifdef  __cplusplus
 }

--- a/lib/dynamic-string.c
+++ b/lib/dynamic-string.c
@@ -59,7 +59,7 @@ ds_reserve(struct ds *ds, size_t min_length)
 {
     if (min_length > ds->allocated || !ds->string) {
         ds->allocated += MAX(min_length, ds->allocated);
-        ds->allocated = MAX(8, ds->allocated);
+        ds->allocated = MAX(256, ds->allocated);
         ds->string = xrealloc(ds->string, ds->allocated + 1);
     }
 }

--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -6373,8 +6373,6 @@ netdev_dpdk_rte_flow_action_handle_create(struct netdev *netdev, bool transfer)
     struct rte_flow_action_handle *action_handle;
     struct rte_flow_error error;
 
-    memset(&error, 0 , sizeof(struct rte_flow_error));
-
     if (!is_dpdk_class(netdev->netdev_class)) {
         return NULL;
     }

--- a/lib/netdev-offload-dpdk.c
+++ b/lib/netdev-offload-dpdk.c
@@ -39,7 +39,8 @@
 #include "conntrack-private.h"
 
 extern __thread int threadid;
-extern uint64_t counter_off[16];
+extern int64_t counter_off[16];
+extern int64_t counter_off_rem[16];
 VLOG_DEFINE_THIS_MODULE(netdev_offload_dpdk);
 static struct vlog_rate_limit rl = VLOG_RATE_LIMIT_INIT(600, 600);
 
@@ -63,6 +64,7 @@ struct ct_flow_data {
     struct rte_flow *rte_flow;
     struct conn_key conn_key;
     uint32_t hash;
+    bool notify;
 };
 
 static void conn_key_extract_from_flow(const struct flow *flow,
@@ -827,6 +829,67 @@ dump_vxlan_encap(struct ds *s, const struct rte_flow_item *items)
     }
 }
 
+#if 0
+static void
+dump_geneve_encap(struct ds *s, const struct rte_flow_item *items)
+{
+    const struct rte_flow_item_eth *eth = NULL;
+    const struct rte_flow_item_ipv4 *ipv4 = NULL;
+    const struct rte_flow_item_ipv6 *ipv6 = NULL;
+    const struct rte_flow_item_udp *udp = NULL;
+    const struct rte_flow_item_geneve *geneve = NULL;
+
+    for (; items && items->type != RTE_FLOW_ITEM_TYPE_END; items++) {
+        if (items->type == RTE_FLOW_ITEM_TYPE_ETH) {
+            eth = items->spec;
+        } else if (items->type == RTE_FLOW_ITEM_TYPE_IPV4) {
+            ipv4 = items->spec;
+        } else if (items->type == RTE_FLOW_ITEM_TYPE_IPV6) {
+            ipv6 = items->spec;
+        } else if (items->type == RTE_FLOW_ITEM_TYPE_UDP) {
+            udp = items->spec;
+        } else if (items->type == RTE_FLOW_ITEM_TYPE_GENEVE) {
+            geneve = items->spec;
+        }
+    }
+
+    ds_put_format(s, "set geneve ip-version %s ",
+                  ipv4 ? "ipv4" : ipv6 ? "ipv6" : "ERR");
+    if (geneve) {
+        ovs_be32 vni;
+
+        vni = get_unaligned_be32(ALIGNED_CAST(ovs_be32 *,
+                                              geneve->vni));
+        ds_put_format(s, "vni %"PRIu32" ", ntohl(vni) >> 8);
+    }
+    if (udp) {
+        ds_put_format(s, "udp-src %"PRIu16" udp-dst %"PRIu16" ",
+                      ntohs(udp->hdr.src_port), ntohs(udp->hdr.dst_port));
+    }
+    if (ipv4) {
+        ds_put_format(s, "ip-src "IP_FMT" ip-dst "IP_FMT" ",
+                      IP_ARGS(ipv4->hdr.src_addr),
+                      IP_ARGS(ipv4->hdr.dst_addr));
+    }
+    if (ipv6) {
+        struct in6_addr addr;
+
+        ds_put_cstr(s, "ip-src ");
+        memcpy(&addr, ipv6->hdr.src_addr, sizeof addr);
+        ipv6_format_mapped(&addr, s);
+        ds_put_cstr(s, " ip-dst ");
+        memcpy(&addr, ipv6->hdr.dst_addr, sizeof addr);
+        ipv6_format_mapped(&addr, s);
+        ds_put_cstr(s, " ");
+    }
+    if (eth) {
+        ds_put_format(s, "eth-src "ETH_ADDR_FMT" eth-dst "ETH_ADDR_FMT,
+                      ETH_ADDR_BYTES_ARGS(eth->src.addr_bytes),
+                      ETH_ADDR_BYTES_ARGS(eth->dst.addr_bytes));
+    }
+}
+#endif
+
 static void
 dump_flow_action(struct ds *s, struct ds *s_extra,
                  struct flow_actions *flow_actions, int act_index)
@@ -975,6 +1038,15 @@ dump_flow_action(struct ds *s, struct ds *s_extra,
         ds_put_cstr(s, "vxlan_encap / ");
         dump_vxlan_encap(s_extra, items);
         ds_put_cstr(s_extra, ";");
+    #if 0
+    } else if (actions->type == RTE_FLOW_ACTION_TYPE_GENEVE_ENCAP) {
+        const struct rte_flow_action_geneve_encap *geneve_encap = actions->conf;
+        const struct rte_flow_item *items = geneve_encap->definition;
+
+        ds_put_cstr(s, "geneve_encap / ");
+        dump_geneve_encap(s_extra, items);
+        ds_put_cstr(s_extra, ";");
+    #endif
     } else if (actions->type == RTE_FLOW_ACTION_TYPE_JUMP) {
         const struct rte_flow_action_jump *jump = actions->conf;
 
@@ -1520,8 +1592,6 @@ parse_geneve_match(struct flow_patterns *patterns,
     consumed_masks->tunnel.metadata.present.map = 0;
     consumed_masks->tunnel.metadata.present.len = 0;
 
-    if(match->flow.tunnel.metadata.present.len)
-        memset(consumed_masks->tunnel.metadata.opts.u8, 0, sizeof(consumed_masks->tunnel.metadata.opts.u8));
     add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_GENEVE, gnv_spec, gnv_mask,
                      NULL);
     return 0;
@@ -2281,6 +2351,103 @@ err:
     return -1;
 }
 
+#if 0
+/* For geneve
+ * ETH / IPv4(6) / UDP / VXLAN / END
+ */
+
+struct rte_flow_action_geneve_encap {
+    /**
+     * Encapsulating geneve tunnel definition
+     * (terminated by the END pattern item).
+     */
+    struct rte_flow_item *definition;
+};
+
+#define ACTION_GENEVE_ENCAP_ITEMS_NUM 5
+
+static int
+add_geneve_encap_action(struct flow_actions *actions,
+                       const void *header)
+{
+    const struct eth_header *eth;
+    const struct udp_header *udp;
+    struct geneve_data {
+        struct rte_flow_action_geneve_encap conf;
+        struct rte_flow_item items[ACTION_GENEVE_ENCAP_ITEMS_NUM];
+    } *geneve_data;
+    BUILD_ASSERT_DECL(offsetof(struct geneve_data, conf) == 0);
+    const void *geneve;
+    const void *l3;
+    const void *l4;
+    int field;
+
+    geneve_data = xzalloc(sizeof *geneve_data);
+    field = 0;
+
+    eth = header;
+    /* Ethernet */
+    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_ETH;
+    geneve_data->items[field].spec = eth;
+    geneve_data->items[field].mask = &rte_flow_item_eth_mask;
+    field++;
+
+    l3 = eth + 1;
+    /* IP */
+    if (eth->eth_type == htons(ETH_TYPE_IP)) {
+        /* IPv4 */
+        const struct ip_header *ip = l3;
+
+        geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        geneve_data->items[field].spec = ip;
+        geneve_data->items[field].mask = &rte_flow_item_ipv4_mask;
+
+        if (ip->ip_proto != IPPROTO_UDP) {
+            goto err;
+        }
+        l4 = (ip + 1);
+    } else if (eth->eth_type == htons(ETH_TYPE_IPV6)) {
+        const struct ovs_16aligned_ip6_hdr *ip6 = l3;
+
+        geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        geneve_data->items[field].spec = ip6;
+        geneve_data->items[field].mask = &rte_flow_item_ipv6_mask;
+
+        if (ip6->ip6_nxt != IPPROTO_UDP) {
+            goto err;
+        }
+        l4 = (ip6 + 1);
+    } else {
+        goto err;
+    }
+    field++;
+
+    udp = l4;
+    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_UDP;
+    geneve_data->items[field].spec = udp;
+    geneve_data->items[field].mask = &rte_flow_item_udp_mask;
+    field++;
+
+    geneve = (udp + 1);
+    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_GENEVE;
+    geneve_data->items[field].spec = geneve;
+    geneve_data->items[field].mask = &rte_flow_item_geneve_mask;
+    field++;
+
+    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_END;
+
+    geneve_data->conf.definition = geneve_data->items;
+
+    add_flow_action(actions, RTE_FLOW_ACTION_TYPE_GENEVE_ENCAP, geneve_data);
+
+    return 0;
+err:
+    free(geneve_data);
+    return -1;
+}
+
+#endif
+
 static int
 parse_vlan_push_action(struct flow_actions *actions,
                        const struct ovs_action_push_vlan *vlan_push)
@@ -2315,6 +2482,12 @@ add_tunnel_push_action(struct flow_actions *actions,
          !add_vxlan_encap_action(actions, tnl_push->header)) {
          return;
      }
+     #if 0
+     else if (tnl_push->tnl_type == OVS_VPORT_TYPE_GENEVE &&
+         !add_geneve_encap_action(actions, tnl_push->header)) {
+         return;
+     }
+     #endif
 
      raw_encap = xzalloc(sizeof *raw_encap);
      raw_encap->data = (uint8_t *) tnl_push->header;
@@ -2661,6 +2834,17 @@ netdev_offload_dpdk_flow_destroy(struct ufid_to_rte_flow_data *rte_flow_data)
                     break;
                 }
                 data->rte_flow = NULL;
+                if(data->notify)
+                {
+                    //counter_off[i]--;
+                    counter_off_rem[i]++;
+                    rte_atomic64_dec(&total_offloaded);
+                    if(rte_atomic64_read(&total_offloaded) <= 0)
+                    {
+                        start = true;
+                        VLOG_ERR("Offloading started");
+                    }
+                }
                 cmap_remove(&rte_flow_data->ct_flows[i], &data->node, data->hash);
                 ovsrcu_postpone(free, data);
             }
@@ -2843,9 +3027,9 @@ netdev_offload_dpdk_flow_notify(struct netdev *netdev, const ovs_u128 *ufid,
     rte_flow_data = ufid_to_rte_flow_data_find(netdev, ufid, false);
     if (OVS_LIKELY(rte_flow_data) && rte_flow_data->ct) {
         hash = hash_ct_tuple(packet_flow);
-        //if(ovs_mutex_trylock(&rte_flow_data->lock[threadid]))
-        //    return -1;
-        ovs_mutex_lock(&rte_flow_data->lock[threadid]);
+        if(ovs_mutex_trylock(&rte_flow_data->lock[threadid]))
+            return -1;
+        //ovs_mutex_lock(&rte_flow_data->lock[threadid]);
         if (cmap_find(&rte_flow_data->ct_flows[threadid], hash) == NULL)
         {
             match = rte_flow_data->match;
@@ -2863,9 +3047,16 @@ netdev_offload_dpdk_flow_notify(struct netdev *netdev, const ovs_u128 *ufid,
             ct_data = xzalloc(sizeof *ct_data);
             ct_data->rte_flow = rte_flow;
             ct_data->hash = hash;
+            ct_data->notify = true;
             conn_key_extract_from_flow(&match.flow, &ct_data->conn_key);
 
             counter_off[threadid]++;
+            rte_atomic64_inc(&total_offloaded);
+            if(rte_atomic64_read(&total_offloaded) >= 800000)
+            {
+                 start = false;          
+                VLOG_ERR("Offloading stopped");
+            }
             cmap_insert(&rte_flow_data->ct_flows[threadid],
                         CONST_CAST(struct cmap_node *, &ct_data->node), hash);
         }
@@ -2994,6 +3185,17 @@ netdev_offload_dpdk_flow_get(struct netdev *netdev,
                     }
                     data->rte_flow = NULL;
                     cmap_remove(&rte_flow_data->ct_flows[i], &data->node, data->hash);
+                    if(data->notify)
+                    {
+                        //counter_off[i]--;
+                        counter_off_rem[i]++;
+                        rte_atomic64_dec(&total_offloaded);
+                        if(rte_atomic64_read(&total_offloaded) <= 0)
+                        {
+                            start = true;
+                            VLOG_ERR("Offloading started");
+                        }
+                    }
                     ovsrcu_postpone(free, data);
                 }
            }


### PR DESCRIPTION
without offload : 50m, 45m, conntrack events.
with offload
38m established , 8m offloaded, stop start , after every 8 Lakh.

export PATH=$PATH:/nic/tools/openvswitch/scripts/
export DB_SOCK=/var/run/openvswitch/db.sock
export DB_FILE=/var/run/openvswitch/conf.db

mkdir -p /var/run/openvswitch/
mkdir /var/log/openvswitch

ovsdb-tool create $DB_FILE /nic/tools/openvswitch/vswitch.ovsschema

echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages cat /proc/meminfo | grep -i huge

ovsdb-server --remote=punix:$DB_SOCK
--remote=db:Open_vSwitch,Open_vSwitch,manager_options --detach --pidfile --log-file --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwitch,SSL,certificate
--bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert  $DB_FILE

ovs-vsctl --no-wait set Open_vSwitch .
other_config:dpdk-socket-mem="1024"
ovs-vsctl --no-wait set Open_vSwitch .
other_config:dpdk-lcore-mask=0xff00
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-mem-channels=4 ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true ovs-vsctl --no-wait set Open_vSwitch .
other_config:per-port-memory=false
ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-main-lcore=0 ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x00ff

ovs-vsctl set Open_vSwitch . other_config:n-offload-threads=8

ovs-vsctl set Open_vSwitch . other_config:max-revalidator=100000 ovs-vsctl set Open_vSwitch . other_config:max-idle=100000

/data/ovs-vswitchd --pidfile --detach --log-file

ovs-vsctl --no-wait add-br br0 -- set bridge br0 datapath_type=netdev ovs-appctl dpctl/ct-set-maxconns 80000000

ovs-vsctl --no-wait add-port br0 dpdk0 -- set Interface dpdk0 type=dpdk options:dpdk-devargs="vdev=net_ionic0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8 ovs-vsctl --no-wait add-port br0 dpdk1 -- set Interface dpdk1 type=dpdk options:dpdk-devargs="vdev=net_ionic1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8

ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br0 "table=0, priority=40, actions=drop"

ovs-appctl vlog/set off