### PR TITLE
Geneve 16  byte header support and code cleanup

### DIFF
--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -6373,6 +6373,8 @@ netdev_dpdk_rte_flow_action_handle_create(struct netdev *netdev, bool transfer)
     struct rte_flow_action_handle *action_handle;
     struct rte_flow_error error;
 
+    memset(&error, 0 , sizeof(struct rte_flow_error));
+
     if (!is_dpdk_class(netdev->netdev_class)) {
         return NULL;
     }

--- a/lib/netdev-offload-dpdk.c
+++ b/lib/netdev-offload-dpdk.c
@@ -829,67 +829,6 @@ dump_vxlan_encap(struct ds *s, const struct rte_flow_item *items)
     }
 }
 
-#if 0
-static void
-dump_geneve_encap(struct ds *s, const struct rte_flow_item *items)
-{
-    const struct rte_flow_item_eth *eth = NULL;
-    const struct rte_flow_item_ipv4 *ipv4 = NULL;
-    const struct rte_flow_item_ipv6 *ipv6 = NULL;
-    const struct rte_flow_item_udp *udp = NULL;
-    const struct rte_flow_item_geneve *geneve = NULL;
-
-    for (; items && items->type != RTE_FLOW_ITEM_TYPE_END; items++) {
-        if (items->type == RTE_FLOW_ITEM_TYPE_ETH) {
-            eth = items->spec;
-        } else if (items->type == RTE_FLOW_ITEM_TYPE_IPV4) {
-            ipv4 = items->spec;
-        } else if (items->type == RTE_FLOW_ITEM_TYPE_IPV6) {
-            ipv6 = items->spec;
-        } else if (items->type == RTE_FLOW_ITEM_TYPE_UDP) {
-            udp = items->spec;
-        } else if (items->type == RTE_FLOW_ITEM_TYPE_GENEVE) {
-            geneve = items->spec;
-        }
-    }
-
-    ds_put_format(s, "set geneve ip-version %s ",
-                  ipv4 ? "ipv4" : ipv6 ? "ipv6" : "ERR");
-    if (geneve) {
-        ovs_be32 vni;
-
-        vni = get_unaligned_be32(ALIGNED_CAST(ovs_be32 *,
-                                              geneve->vni));
-        ds_put_format(s, "vni %"PRIu32" ", ntohl(vni) >> 8);
-    }
-    if (udp) {
-        ds_put_format(s, "udp-src %"PRIu16" udp-dst %"PRIu16" ",
-                      ntohs(udp->hdr.src_port), ntohs(udp->hdr.dst_port));
-    }
-    if (ipv4) {
-        ds_put_format(s, "ip-src "IP_FMT" ip-dst "IP_FMT" ",
-                      IP_ARGS(ipv4->hdr.src_addr),
-                      IP_ARGS(ipv4->hdr.dst_addr));
-    }
-    if (ipv6) {
-        struct in6_addr addr;
-
-        ds_put_cstr(s, "ip-src ");
-        memcpy(&addr, ipv6->hdr.src_addr, sizeof addr);
-        ipv6_format_mapped(&addr, s);
-        ds_put_cstr(s, " ip-dst ");
-        memcpy(&addr, ipv6->hdr.dst_addr, sizeof addr);
-        ipv6_format_mapped(&addr, s);
-        ds_put_cstr(s, " ");
-    }
-    if (eth) {
-        ds_put_format(s, "eth-src "ETH_ADDR_FMT" eth-dst "ETH_ADDR_FMT,
-                      ETH_ADDR_BYTES_ARGS(eth->src.addr_bytes),
-                      ETH_ADDR_BYTES_ARGS(eth->dst.addr_bytes));
-    }
-}
-#endif
-
 static void
 dump_flow_action(struct ds *s, struct ds *s_extra,
                  struct flow_actions *flow_actions, int act_index)
@@ -1038,15 +977,6 @@ dump_flow_action(struct ds *s, struct ds *s_extra,
         ds_put_cstr(s, "vxlan_encap / ");
         dump_vxlan_encap(s_extra, items);
         ds_put_cstr(s_extra, ";");
-    #if 0
-    } else if (actions->type == RTE_FLOW_ACTION_TYPE_GENEVE_ENCAP) {
-        const struct rte_flow_action_geneve_encap *geneve_encap = actions->conf;
-        const struct rte_flow_item *items = geneve_encap->definition;
-
-        ds_put_cstr(s, "geneve_encap / ");
-        dump_geneve_encap(s_extra, items);
-        ds_put_cstr(s_extra, ";");
-    #endif
     } else if (actions->type == RTE_FLOW_ACTION_TYPE_JUMP) {
         const struct rte_flow_action_jump *jump = actions->conf;
 
@@ -1592,6 +1522,8 @@ parse_geneve_match(struct flow_patterns *patterns,
     consumed_masks->tunnel.metadata.present.map = 0;
     consumed_masks->tunnel.metadata.present.len = 0;
 
+    if(match->flow.tunnel.metadata.present.len)
+        memset(consumed_masks->tunnel.metadata.opts.u8, 0, sizeof(consumed_masks->tunnel.metadata.opts.u8));
     add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_GENEVE, gnv_spec, gnv_mask,
                      NULL);
     return 0;
@@ -2351,103 +2283,6 @@ err:
     return -1;
 }
 
-#if 0
-/* For geneve
- * ETH / IPv4(6) / UDP / VXLAN / END
- */
-
-struct rte_flow_action_geneve_encap {
-    /**
-     * Encapsulating geneve tunnel definition
-     * (terminated by the END pattern item).
-     */
-    struct rte_flow_item *definition;
-};
-
-#define ACTION_GENEVE_ENCAP_ITEMS_NUM 5
-
-static int
-add_geneve_encap_action(struct flow_actions *actions,
-                       const void *header)
-{
-    const struct eth_header *eth;
-    const struct udp_header *udp;
-    struct geneve_data {
-        struct rte_flow_action_geneve_encap conf;
-        struct rte_flow_item items[ACTION_GENEVE_ENCAP_ITEMS_NUM];
-    } *geneve_data;
-    BUILD_ASSERT_DECL(offsetof(struct geneve_data, conf) == 0);
-    const void *geneve;
-    const void *l3;
-    const void *l4;
-    int field;
-
-    geneve_data = xzalloc(sizeof *geneve_data);
-    field = 0;
-
-    eth = header;
-    /* Ethernet */
-    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_ETH;
-    geneve_data->items[field].spec = eth;
-    geneve_data->items[field].mask = &rte_flow_item_eth_mask;
-    field++;
-
-    l3 = eth + 1;
-    /* IP */
-    if (eth->eth_type == htons(ETH_TYPE_IP)) {
-        /* IPv4 */
-        const struct ip_header *ip = l3;
-
-        geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_IPV4;
-        geneve_data->items[field].spec = ip;
-        geneve_data->items[field].mask = &rte_flow_item_ipv4_mask;
-
-        if (ip->ip_proto != IPPROTO_UDP) {
-            goto err;
-        }
-        l4 = (ip + 1);
-    } else if (eth->eth_type == htons(ETH_TYPE_IPV6)) {
-        const struct ovs_16aligned_ip6_hdr *ip6 = l3;
-
-        geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_IPV6;
-        geneve_data->items[field].spec = ip6;
-        geneve_data->items[field].mask = &rte_flow_item_ipv6_mask;
-
-        if (ip6->ip6_nxt != IPPROTO_UDP) {
-            goto err;
-        }
-        l4 = (ip6 + 1);
-    } else {
-        goto err;
-    }
-    field++;
-
-    udp = l4;
-    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_UDP;
-    geneve_data->items[field].spec = udp;
-    geneve_data->items[field].mask = &rte_flow_item_udp_mask;
-    field++;
-
-    geneve = (udp + 1);
-    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_GENEVE;
-    geneve_data->items[field].spec = geneve;
-    geneve_data->items[field].mask = &rte_flow_item_geneve_mask;
-    field++;
-
-    geneve_data->items[field].type = RTE_FLOW_ITEM_TYPE_END;
-
-    geneve_data->conf.definition = geneve_data->items;
-
-    add_flow_action(actions, RTE_FLOW_ACTION_TYPE_GENEVE_ENCAP, geneve_data);
-
-    return 0;
-err:
-    free(geneve_data);
-    return -1;
-}
-
-#endif
-
 static int
 parse_vlan_push_action(struct flow_actions *actions,
                        const struct ovs_action_push_vlan *vlan_push)
@@ -2482,12 +2317,6 @@ add_tunnel_push_action(struct flow_actions *actions,
          !add_vxlan_encap_action(actions, tnl_push->header)) {
          return;
      }
-     #if 0
-     else if (tnl_push->tnl_type == OVS_VPORT_TYPE_GENEVE &&
-         !add_geneve_encap_action(actions, tnl_push->header)) {
-         return;
-     }
-     #endif
 
      raw_encap = xzalloc(sizeof *raw_encap);
      raw_encap->data = (uint8_t *) tnl_push->header;


### PR DESCRIPTION
Geneve option data is restricted to 32bit (4 byte) for now.
So 4 byte for the option header, and 4 bytes for the data.

To enable 16 byte geneve header with option data, the following extra configuration with conn-tracking needs to be done:

On One side:

```
start-dp-app.sh
export PATH=$PATH:/nic/tools/openvswitch/scripts//
export DB_SOCK=/var/run/openvswitch/db.sock
export DB_FILE=/var/run/openvswitch/conf.db
mkdir -p /var/run/openvswitch/
mkdir /var/log/openvswitch
ovsdb-tool create $DB_FILE /nic/tools/openvswitch/vswitch.ovsschema
echo 4096 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
ovsdb-server --remote=punix:$DB_SOCK  --remote=db:Open_vSwitch,Open_vSwitch,manager_options --detach   --pidfile --log-file --private-key=db:Open_vSwitch,SSL,private_key  --certificate=db:Open_vSwitch,SSL,certificate   --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert  $DB_FILE
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="2048"
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0xff
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-mem-channels=4
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
ovs-vsctl --no-wait set Open_vSwitch . other_config:per-port-memory=false
ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=false
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-main-lcore=0
 
ovs-vswitchd --pidfile --detach --log-file
ovs-vsctl --no-wait add-br br0 -- set bridge br0 datapath_type=netdev
ovs-vsctl add-port br0 geneve11 -- set interface geneve11 type=geneve options:local_ip=1.1.1.2 options:remote_ip=1.1.1.1 options:key=100
ovs-vsctl --no-wait add-port br0 dpdk2 -- set Interface dpdk2 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ovs-vsctl --no-wait add-br br-phy -- set bridge br-phy datapath_type=netdev
ovs-vsctl --no-wait add-port br-phy dpdk0 -- set Interface dpdk0 type=dpdk options:dpdk-devargs="vdev=net_ionic0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ip addr add dev br-phy 1.1.1.2/24
ifconfig br-phy up

ovs-vsctl --no-wait add-br br1 -- set bridge br1 datapath_type=netdev
ovs-vsctl add-port br1 geneve12 -- set interface geneve12 type=geneve options:local_ip=2.2.2.2 options:remote_ip=2.2.2.1 options:key=200
ovs-vsctl --no-wait add-port br1 dpdk3 -- set Interface dpdk3 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ovs-vsctl --no-wait add-br br-phy1 -- set bridge br-phy1 datapath_type=netdev
ovs-vsctl --no-wait add-port br-phy1 dpdk1 -- set Interface dpdk1 type=dpdk options:dpdk-devargs="vdev=net_ionic1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ip addr add dev br-phy1 2.2.2.2/24
ifconfig br-phy1 up
 
ovs-appctl vlog/set off
 
###FOR 16 BYTE GENEVE HEADER### 
 
ovs-ofctl add-flow br0 "table=1, priority=80, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=1, priority=70, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br0 "table=1, priority=60, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br0 "table=1, priority=40, actions=normal"
ovs-ofctl add-flow br0 "table=0, priority=50, actions=resubmit(,1)"
ovs-ofctl add-tlv-map br0 "{class=0x0102,type=0x80,len=4}->tun_metadata0"
ovs-ofctl add-flow br0 "table=0, priority=60, ip,actions=set_field:0x0908->tun_metadata0,resubmit(,1)"

ovs-ofctl add-flow br1 "table=1, priority=80, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br1 "table=1, priority=70, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br1 "table=1, priority=60, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br1 "table=1, priority=40, actions=normal"
ovs-ofctl add-flow br1 "table=0, priority=50, actions=resubmit(,1)"
ovs-ofctl add-tlv-map br1 "{class=0x0102,type=0x80,len=4}->tun_metadata0"
ovs-ofctl add-flow br1 "table=0, priority=60, ip,actions=set_field:0x0908->tun_metadata0,resubmit(,1)"

#-------------------------------------------------------------------------------------------
#### On host, run the following commands 
ifconfig enp200s0 20.0.1.33/24
ifconfig enp200s0 hw ether 04:aa:bb:cc:dd:07
ip link set dev enp200s0 mtu 1400

ifconfig enp199s0 10.0.1.33/24
ifconfig enp199s0 hw ether 04:aa:bb:cc:dd:06
ip link set dev enp199s0 mtu 1400

#start iperf server, with sudo
iperf -s


```
On another side:

```
start-dp-app.sh
export PATH=$PATH:/nic/tools/openvswitch/scripts/
export DB_SOCK=/var/run/openvswitch/db.sock
export DB_FILE=/var/run/openvswitch/conf.db
mkdir -p /var/run/openvswitch/
mkdir /var/log/openvswitch
ovsdb-tool create $DB_FILE /nic/tools/openvswitch/vswitch.ovsschema
echo 4096 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
ovsdb-server --remote=punix:$DB_SOCK  --remote=db:Open_vSwitch,Open_vSwitch,manager_options --detach   --pidfile --log-file --private-key=db:Open_vSwitch,SSL,private_key  --certificate=db:Open_vSwitch,SSL,certificate   --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert  $DB_FILE
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="2048"
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0xff
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-mem-channels=4
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
ovs-vsctl --no-wait set Open_vSwitch . other_config:per-port-memory=false
ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-main-lcore=0
 
ovs-vsctl set Open_vSwitch . other_config:max-revalidator=100000
ovs-vsctl set Open_vSwitch . other_config:max-idle=100000
 
ovs-vswitchd --pidfile --detach --log-file
ovs-vsctl --no-wait add-br br0 -- set bridge br0 datapath_type=netdev
ovs-vsctl add-port br0 geneve11 -- set interface geneve11 type=geneve options:local_ip=1.1.1.1 options:remote_ip=1.1.1.2 options:key=100
ovs-vsctl --no-wait add-port br0 dpdk2 -- set Interface dpdk2 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
ovs-vsctl --no-wait add-br br-phy -- set bridge br-phy datapath_type=netdev
ovs-vsctl --no-wait add-port br-phy dpdk0 -- set Interface dpdk0 type=dpdk options:dpdk-devargs="vdev=net_ionic0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ip addr add dev br-phy 1.1.1.1/24
ifconfig br-phy up

ovs-vsctl --no-wait add-br br1 -- set bridge br1 datapath_type=netdev
ovs-vsctl add-port br1 geneve12 -- set interface geneve12 type=geneve options:local_ip=2.2.2.1 options:remote_ip=2.2.2.2 options:key=200
ovs-vsctl --no-wait add-port br1 dpdk3 -- set Interface dpdk3 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ovs-vsctl --no-wait add-br br-phy1 -- set bridge br-phy1 datapath_type=netdev
ovs-vsctl --no-wait add-port br-phy1 dpdk1 -- set Interface dpdk1 type=dpdk options:dpdk-devargs="vdev=net_ionic1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8

ip addr add dev br-phy1 2.2.2.1/24
ifconfig br-phy1 up

ovs-vsctl --no-wait add-br br2 -- set bridge br2 datapath_type=netdev
ovs-vsctl --no-wait add-port br2 dpdk4 -- set Interface dpdk4 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf0vf0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
ovs-vsctl --no-wait add-port br2 dpdk5 -- set Interface dpdk5 type=dpdk options:dpdk-devargs="vdev=net_ionic,representor=pf0vf1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8

##### FOR 8 BYTE GENEVE HEADER ####### 
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
 
ovs-ofctl add-flow br1 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br1 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br1 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br1 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
 
ovs-ofctl add-flow br2 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br2 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br2 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br2 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
#-----------------------------------------------------------------
##### FOR 16 BYTE GENEVE HEADER ####### 
ovs-ofctl add-flow br0 "table=1, priority=80, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=1, priority=70, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br0 "table=1, priority=60, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br0 "table=1, priority=40, actions=normal"
ovs-ofctl add-flow br0 "table=0, priority=50, actions=resubmit(,1)"
ovs-ofctl add-tlv-map br0 "{class=0x0102,type=0x80,len=4}->tun_metadata0"
ovs-ofctl add-flow br0 "table=0, priority=60, ip,actions=set_field:0x0809->tun_metadata0,resubmit(,1)"

ovs-ofctl add-flow br1 "table=1, priority=80, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br1 "table=1, priority=70, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br1 "table=1, priority=60, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br1 "table=1, priority=40, actions=normal"
ovs-ofctl add-flow br1 "table=0, priority=50, actions=resubmit(,1)"
ovs-ofctl add-tlv-map br1 "{class=0x0102,type=0x80,len=4}->tun_metadata0"
ovs-ofctl add-flow br1 "table=0, priority=60, ip,actions=set_field:0x0809->tun_metadata0,resubmit(,1)"

ovs-ofctl add-flow br2 "table=1, priority=80, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br2 "table=1, priority=70, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br2 "table=1, priority=60, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br2 "table=1, priority=40, actions=normal"
ovs-ofctl add-flow br2 "table=0, priority=50, actions=resubmit(,1)"
ovs-ofctl add-tlv-map br2 "{class=0x0102,type=0x80,len=4}->tun_metadata0"
ovs-ofctl add-flow br2 "table=0, priority=60, ip,actions=set_field:0x0809->tun_metadata0,resubmit(,1)"
#-----------------------------------------------------------------------------------------------
tail -f /var/log/openvswitch/ovs-vswitchd.log | grep "Hw P" &
tail -f /var/log/openvswitch/ovs-vswitchd.log | grep "nexthop" &
tail -f /var/log/openvswitch/ovs-vswitchd.log | grep "counter" &
 
#to enable logs for certain ovs modules
ovs-appctl vlog/list 
ovs-appctl vlog/set dpdk
ovs-appctl vlog/set netdev_dpdk
ovs-appctl vlog/set netdev_offload_dpdk
ovs-appctl vlog/set dpif_netdev
ovs-appctl vlog/set tunnel
ovs-appctl vlog/set conntrack

#to disable all logs
ovs-appctl vlog/set off
 
#ON HOST, with sudo
ifconfig enp200s0 20.0.1.32/24
ip link set dev enp200s0 mtu 1400
 
ifconfig enp199s0 10.0.1.32/24
ip link set dev enp199s0 mtu 1400

echo 2 > /sys/class/net/enp199s0/device/sriov_numvfs
ip netns add vrf1
ip link set enp199s0v1 netns vrf1
ip netns exec vrf1 ifconfig enp199s0v1 30.0.1.33/24
ifconfig enp199s0v0 30.0.1.32/24
ping 30.0.1.33

#start iperf server on the vf side
ip netns exec vrf1 iperf -s

#On Another terminal instance start iperf client with 1 connection, as indicated by -P1, that can be changed as shown below:
iperf -c 30.0.1.33 -P1 -t 100 -i 10 &
iperf -c 20.0.1.33 -P1 -t 100 -i 10 &
iperf -c 10.0.1.33 -P1 -t 100 -i 10 &

# ===========OR=========== 
iperf -c 30.0.1.33 -P8 -t 100 -i 10 &
iperf -c 20.0.1.33 -P8 -t 100 -i 10 &
iperf -c 10.0.1.33 -P8 -t 100 -i 10 &

# ===========OR===========
iperf -c 30.0.1.33 -P100 -t 100 -i 10 &
iperf -c 20.0.1.33 -P100 -t 100 -i 10 &
iperf -c 10.0.1.33 -P100 -t 100 -i 10 &



```