### PR TITLE
Producer code for conntrack logging with header file

### DIFF
--- a/lib/automake.mk
+++ b/lib/automake.mk
@@ -394,6 +394,7 @@ lib_libopenvswitch_la_SOURCES = \
 	lib/vconn.c \
 	lib/versions.h \
 	lib/vl-mff-map.h \
+	lib/vpp_raw_decoder.h\
 	lib/vlan-bitmap.c \
 	lib/vlan-bitmap.h \
 	lib/vlog.c \

--- a/lib/vpp_raw_decoder.h
+++ b/lib/vpp_raw_decoder.h
@@ -1,0 +1,22 @@
+// {C} Copyright 2021 Pensando Systems Inc. All rights reserved
+#ifndef __IPC_RAW__HPP__
+#define __IPC_RAW__HPP__
+
+#define SHM_NAME "/conn_shared_memory" // Shared memory name
+#define SHM_SIZE 4096                 // Shared memory size
+
+typedef struct operd_flow_key_v4 {
+    uint32_t src;
+    uint32_t dst;
+    uint16_t sport;
+    uint16_t dport;
+    uint8_t proto;
+} operd_flow_key_v4_t;
+
+typedef struct operd_flow {
+    operd_flow_key_v4_t v4_tuple;
+    uint64_t time;
+    uint8_t state;
+} operd_flow_t;
+
+#endif


### PR DESCRIPTION
Producer code for conntrack logging with header file
```
export PATH=$PATH:/nic/tools/openvswitch/scripts/
export DB_SOCK=/var/run/openvswitch/db.sock
export DB_FILE=/var/run/openvswitch/conf.db 
mkdir -p /var/run/openvswitch/
mkdir /var/log/openvswitch
ovsdb-tool create $DB_FILE /nic/tools/openvswitch/vswitch.ovsschema
echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
cat /proc/meminfo | grep -i huge
ovsdb-server --remote=punix:$DB_SOCK  --remote=db:Open_vSwitch,Open_vSwitch,manager_options --detach   --pidfile --log-file --private-key=db:Open_vSwitch,SSL,private_key  --certificate=db:Open_vSwitch,SSL,certificate   --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert  $DB_FILE

ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="1024"
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0xff00
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-mem-channels=4
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
ovs-vsctl --no-wait set Open_vSwitch . other_config:per-port-memory=false
ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true
ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-main-lcore=0
ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x00ff
ovs-vsctl set Open_vSwitch . other_config:max-revalidator=100000
ovs-vsctl set Open_vSwitch . other_config:max-idle=100000

ovs-vsctl set Open_vSwitch . other_config:n-offload-threads=8
ovs-vswitchd --pidfile --detach --log-file
ovs-vsctl --no-wait add-br br0 -- set bridge br0 datapath_type=netdev
ovs-appctl dpctl/ct-set-maxconns 80000000

#uplinks
ovs-vsctl --no-wait add-port br0 dpdk0 -- set Interface dpdk0 type=dpdk options:dpdk-devargs="vdev=net_ionic0"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
ovs-vsctl --no-wait add-port br0 dpdk1 -- set Interface dpdk1 type=dpdk options:dpdk-devargs="vdev=net_ionic1"  options:mtu=9216 options:n_txq=8 options:n_txq_desc=16 options:n_rxq_desc=16 options:n_rxq=8
 
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=-trk, tcp, actions=ct(table=0)"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+new, tcp, actions=ct(commit),normal"
ovs-ofctl add-flow br0 "table=0, priority=50, ct_state=+trk+est, tcp, actions=normal"
ovs-ofctl add-flow br0 "table=0, priority=40, actions=drop"
 
ovs-appctl vlog/set off
ovs-appctl vlog/set conntrack 
ovs-appctl dpctl/offload-stats-show
 
start-dp-app.sh
 
pdsctl debug update port --admin-state up --port Eth1/1 --auto-neg disable --speed 100g
pdsctl debug update port --admin-state down --port Eth1/1
pdsctl debug update port --admin-state up --port Eth1/1
 
pdsctl debug update port --admin-state up --port Eth1/2 --auto-neg disable --speed 100g
pdsctl debug update port --admin-state down --port Eth1/2
pdsctl debug update port --admin-state up --port Eth1/2
pdsctl show port status
```