### PR TITLE
Updated Producer code for logs into shm

### DIFF
--- a/lib/vpp_raw_decoder.h
+++ b/lib/vpp_raw_decoder.h
@@ -3,7 +3,7 @@
 #define __IPC_RAW__HPP__
 
 #define SHM_NAME "/conn_shared_memory" // Shared memory name
-#define SHM_SIZE 4096                 // Shared memory size
+#define SHM_SIZE 524288              // Shared memory size 512*1024
 
 typedef struct operd_flow_key_v4 {
     uint32_t src;


### PR DESCRIPTION
Run in nic/docker:
```
make V=1 ASIC=elba PIPELINE=rudra PLATFORM=hw ARCH=aarch64 tmagent.gobin
```
Generated files: [sw/nic/build/aarch64/rudra/elba/out/tmagent_gobin/tmagent.gobin](http://github.com/pensando/sw/nic/build/aarch64/rudra/elba/out/tmagent_gobin/tmagent.gobin)

Running conntack log

Steps to run:

Run ovs daemon with ovs-vswitchd file shared.
Set logging on:
```
ovs-appctl vlog/set off
ovs-appctl vlog/set conntrack
```
Store tmagent.gobin inside the /data/ folder of ELBA card.
Run following commands:
```
./tmagent.gobin &
curl -X POST -H "Content-Type: application/json" -d '{"logsize": 100000000}' http://localhost:9013/api/debug/logsize
curl localhost:9013/api/debug/logcount
```
check logcount is 0.
Send the traffic
Now logs will be visible in /data/out_file and log count will be visible from “curl localhost:9013/api/debug/logcount”